### PR TITLE
Don't send empty summary email

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.1] - 2024-12-16
+
+- Don't send daily summary email if no events have been logged
+- Fix version in `pyproject.toml`
+
 ## [0.4.0] - 2024-12-13
 
 - Add maillog announcement string to messages logged via python's `logging` module

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "maillog"
-version = "0.3"
+version = "0.4.1"
 description = "Simple python mail logging library."
 authors = ["virtu <virtu@21.ninja>"]
 license = "MIT"

--- a/src/maillog/mail/scheduler.py
+++ b/src/maillog/mail/scheduler.py
@@ -86,7 +86,6 @@ class MailScheduler(threading.Thread):
             now = dt.datetime.now(dt.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
             log.debug("Woke up at %s. Trying to send summary mail...", now)
             self.send_summary_mail()
-            log.debug("Sent summary email.")
 
     def send_summary_mail(self):
         """Format and send summary email."""
@@ -94,6 +93,9 @@ class MailScheduler(threading.Thread):
         subject = f"Maillog summary for {hostname} on {dt.datetime.now(dt.timezone.utc).date()}"
         with EventBuffer() as buf:
             events = buf.get_all_events()
+        if not events:
+            log.info("No events to send in summary email.")
+            return
         body = EventFormatter.pretty_print(events)
         try:
             self.mailer.send(subject, body)


### PR DESCRIPTION
If no events have been logged during a day, don't send a summary mail.

- [x] Test (wait for daily summary mail)
- [x] Merge
- [x] Integrate & Deploy (update p2p-crawler and nix repo inputs, deploy to sphnix, gravity)